### PR TITLE
publish.addEvent

### DIFF
--- a/lib/Publisher.js
+++ b/lib/Publisher.js
@@ -118,5 +118,11 @@ module.exports = function Publisher(options) {
         return Q.all(promises);
     };
 
+    that.publish.addEvent = function (eventName) {
+        if (options.events && options.events.indexOf(eventName) === -1) {
+            options.events.push(eventName);
+        }
+    };
+
     that.emitter = emitter(normalListeners, oneTimeListeners, matchListeners, regExpHash, options.events);
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "promise",
     "wildcard"
   ],
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "YuzuJS",
   "contributors": [
     "Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com)",

--- a/test/B publish.addEvent.coffee
+++ b/test/B publish.addEvent.coffee
@@ -1,0 +1,28 @@
+Publisher = require("..").Publisher
+
+describe "publish.addEvent", ->
+    publisher = null
+    emitter = null
+
+    describe "when adding an event", ->
+        beforeEach ->
+            publisher = new Publisher(events: ["event1", "event2"])
+            emitter = publisher.emitter
+            publisher.publish.addEvent("event3")
+
+        it "should publish the supplied events as usual", ->
+            listener1 = sinon.spy()
+            listener2 = sinon.spy()
+            listener3 = sinon.spy()
+
+            emitter.on("event1", listener1)
+            emitter.on("event2", listener2)
+            emitter.on("event3", listener3)
+
+            publisher.publish("event1")
+            publisher.publish("event2")
+            publisher.publish("event3")
+
+            listener1.should.have.been.called
+            listener2.should.have.been.called
+            listener3.should.have.been.called


### PR DESCRIPTION
Allow the publisher to dynamically add events after the publisher has been created with `publish.addEvent`.